### PR TITLE
Fix colorbar to work with Bootstrap 4's input group.

### DIFF
--- a/src/password.js
+++ b/src/password.js
@@ -181,6 +181,11 @@
         $graybar.append($colorbar)
       );
 
+      // If we're using bootstrap's input group class
+      if ($object.parent().hasClass('input-group')) {
+        $insert.addClass('input-group');
+      }
+
       $object.parent().addClass('pass-strength-visible');
       if (options.animate) {
         $insert.css('display', 'none');

--- a/test/fixture.html
+++ b/test/fixture.html
@@ -4,5 +4,8 @@
     <body>
         <input type="password" id="password" />
         <input type="text" id="username" />
+        <div class="input-group">
+            <input type="password" class="form-control" id="input-group-password">
+        </div>
     </body>
 </html>

--- a/test/password.spec.js
+++ b/test/password.spec.js
@@ -188,5 +188,15 @@ describe('$.fn.password', () => {
         .val('_~%8::%nqy^7e~!!z!;N')
         .trigger('keyup')
     })
+
+    it('adds input group class if inside a bootstrap input group', (done) => {
+      var $inputGroupPass = $('#input-group-password');
+      $inputGroupPass.password();
+
+      expect($('.pass-wrapper')).toBeInDOM();
+      expect($inputGroupPass.next().hasClass('input-group'));
+
+      done();
+    });
   })
 })


### PR DESCRIPTION
Addressing #3 

This works with bootstrap 4 (the newest version). Might be a flaky solution, since it's hardcoded.